### PR TITLE
Updated createApolloSubscriptionServer.js

### DIFF
--- a/imports/api/apollo/server/createApolloSubscriptionServer.js
+++ b/imports/api/apollo/server/createApolloSubscriptionServer.js
@@ -5,7 +5,7 @@ const WS_URL = process.env.WS_URL || `localhost:3005`;
 const wsUrlParts = WS_URL.split(':');
 const WS_PORT = wsUrlParts[wsUrlParts.length - 1];
 
-Meteor.settings.public.WS_URL = process.env.WS_URL || `localhost:3005`;
+Meteor.settings.public.WS_URL = process.env.WS_URL || `ws://localhost:3005`;
 
 function createApolloSubscriptionServer({ subscriptionManager }) {
     const httpServer = createServer((request, response) => {


### PR DESCRIPTION
Bugfix for "Failed to construct 'WebSocket': The URL's scheme must be either 'ws' or 'wss'. 'localhost' is not allowed" received in browser.  Thanks.